### PR TITLE
Decoder generates a trap for ADD instruction (Issue #6)

### DIFF
--- a/src/main/scala/decoder/I/register.scala
+++ b/src/main/scala/decoder/I/register.scala
@@ -32,7 +32,7 @@ private class RegisterControlSignals(override val config: AdeptConfig,
     io.sel_rf_wb         := core_ctl_signals.result_alu
 
     // Check if the 7 MSBs respect the instruction set
-    when (imm =/= 0.U && imm =/= "b0100000".U){
+    when (imm =/= 0.U && imm =/= "b0100000".U) {
       io.trap := true.B         
     } .otherwise {
       io.trap := false.B

--- a/src/main/scala/decoder/I/register.scala
+++ b/src/main/scala/decoder/I/register.scala
@@ -5,8 +5,6 @@ import chisel3._
 import adept.config.AdeptConfig
 import adept.decoder.{InstructionControlSignals, InstructionDecoderOutput}
 
-// TODO: Check if immediate is zero or has a single bit set to one in position
-// 5, else throw trap.
 private class RegisterControlSignals(override val config: AdeptConfig,
                          instruction: UInt, decoder_out: InstructionDecoderOutput)
     extends InstructionControlSignals(config, instruction, decoder_out) {
@@ -32,6 +30,13 @@ private class RegisterControlSignals(override val config: AdeptConfig,
     io.sel_operand_a     := core_ctl_signals.sel_oper_A_rs1
     io.sel_operand_b     := core_ctl_signals.sel_oper_B_rs2
     io.sel_rf_wb         := core_ctl_signals.result_alu
+
+    // Check if the 7 MSBs respect the instruction set
+    when (imm =/= 0.U && imm =/= "b0100000".U){
+      io.trap := true.B         
+    } .otherwise {
+      io.trap := false.B
+    }    
   }
 
 }

--- a/src/test/scala/decoder/decoderUnitTester.scala
+++ b/src/test/scala/decoder/decoderUnitTester.scala
@@ -6,15 +6,20 @@ import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
 import adept.config.AdeptConfig
 
 import adept.decoder.tests.imm._
+import adept.decoder.tests.reg._
 
 class DecoderTestBase(c: InstructionDecoder) extends PeekPokeTester(c) {
   val op_code = new OpCodes
   val slli = 1  //b001
+  val funct7alu = Integer.parseInt("0100000", 2);
 }
 
 class DecoderUnitTesterAll(e: InstructionDecoder) extends PeekPokeTester(e) {
     // Immediate Type Instructions
     new SLLI(e)
+
+    // Register Type Instructions
+    new ADD(e)    
 }
 
 class DecoderTester extends ChiselFlatSpec {
@@ -29,4 +34,13 @@ class DecoderTester extends ChiselFlatSpec {
       e => new SLLI(e)
     } should be (true)
   }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Register Type Instructions
+  ////////////////////////////////////////////////////////////////////////////
+  "Decoder" should s"test ADD instruction (with verilator)" in {
+    Driver(() => new InstructionDecoder(config), "verilator") {
+      e => new ADD(e)
+    } should be (true)
+  }  
 }

--- a/src/test/scala/decoder/reg_tests.scala
+++ b/src/test/scala/decoder/reg_tests.scala
@@ -14,14 +14,16 @@ class ADD(c: InstructionDecoder) extends DecoderTestBase(c) {
   private def ADD(rs1: Int, rs2: Int, imm: Int, rd: Int) {
     val instr = (((127 & imm) << 25) | ((31 & rs2) << 20) | 
                  ((31 & rs1) << 15) | ((31 & rd) << 7) | op_code.Registers.litValue())     
-    val new_imm = if ((imm >> 6) == 1)
+    val new_imm = if ((imm >> 6) == 1) {
                     ((0xFFFFFFF << 7) | imm)
-                  else 
+                  } else {
                     imm
-    val trap = if ((imm == 0) || (imm == funct7alu))
+                  }
+    val trap = if ((imm == 0) || (imm == funct7alu)) {
                  0
-               else
+               } else {
                  1                    
+               }
     poke(c.io.stall_reg, false)
     poke(c.io.basic.instruction, instr)
     
@@ -33,8 +35,9 @@ class ADD(c: InstructionDecoder) extends DecoderTestBase(c) {
     expect(c.io.basic.out.registers.rs2_sel, rs2)
     expect(c.io.basic.out.immediate, new_imm)
     expect(c.io.basic.out.trap, trap)
-    if (imm == 0) 
+    if (imm == 0) {
       expect(c.io.basic.out.alu.op, AluOps.add)    
+    }
     expect(c.io.basic.out.sel_rf_wb, AdeptControlSignals.result_alu)
     expect(c.io.basic.out.sel_operand_a, AdeptControlSignals.sel_oper_A_rs1)
     expect(c.io.basic.out.sel_operand_b, AdeptControlSignals.sel_oper_B_rs2)
@@ -44,12 +47,13 @@ class ADD(c: InstructionDecoder) extends DecoderTestBase(c) {
     var rs1 = rnd.nextInt(32)
     var rs2 = rnd.nextInt(32)
     val random = rnd.nextInt(128)
-    val imm = if (random % 2 == 0)
+    val imm = if (random % 2 == 0) {
                 0
-              else if (random % 5 == 0)
+              } else if (random % 5 == 0) {
                 funct7alu
-              else
+              } else {
                 random
+              }
     val rd  = rnd.nextInt(32)
     
     ADD(rs1, rs2, imm, rd)

--- a/src/test/scala/decoder/reg_tests.scala
+++ b/src/test/scala/decoder/reg_tests.scala
@@ -45,7 +45,7 @@ class ADD(c: InstructionDecoder) extends DecoderTestBase(c) {
     expect(c.io.basic.out.sel_operand_b, AdeptControlSignals.sel_oper_B_rs2)
   }
 
-  for (i <- 0 until 10000) {
+  for (i <- 0 until 100) {
     var rs1 = rnd.nextInt(32)
     var rs2 = rnd.nextInt(32)
     val random = rnd.nextInt(128)

--- a/src/test/scala/decoder/reg_tests.scala
+++ b/src/test/scala/decoder/reg_tests.scala
@@ -44,8 +44,8 @@ class ADD(c: InstructionDecoder) extends DecoderTestBase(c) {
   }
 
   for (i <- 0 until 100) {
-    var rs1 = rnd.nextInt(32)
-    var rs2 = rnd.nextInt(32)
+    val rs1 = rnd.nextInt(32)
+    val rs2 = rnd.nextInt(32)
     val random = rnd.nextInt(128)
     val imm = if (random % 2 == 0) {
                 0

--- a/src/test/scala/decoder/reg_tests.scala
+++ b/src/test/scala/decoder/reg_tests.scala
@@ -32,14 +32,9 @@ class ADD(c: InstructionDecoder) extends DecoderTestBase(c) {
     expect(c.io.basic.out.registers.rs1_sel, rs1)
     expect(c.io.basic.out.registers.rs2_sel, rs2)
     expect(c.io.basic.out.immediate, new_imm)
-    if (imm == 0) {
-      expect(c.io.basic.out.trap, trap)
+    expect(c.io.basic.out.trap, trap)
+    if (imm == 0) 
       expect(c.io.basic.out.alu.op, AluOps.add)    
-    } else if (imm == funct7alu) {
-      expect(c.io.basic.out.trap, trap)
-    } else {
-      expect(c.io.basic.out.trap, trap)
-    }
     expect(c.io.basic.out.sel_rf_wb, AdeptControlSignals.result_alu)
     expect(c.io.basic.out.sel_operand_a, AdeptControlSignals.sel_oper_A_rs1)
     expect(c.io.basic.out.sel_operand_b, AdeptControlSignals.sel_oper_B_rs2)

--- a/src/test/scala/decoder/reg_tests.scala
+++ b/src/test/scala/decoder/reg_tests.scala
@@ -1,0 +1,62 @@
+package adept.decoder.tests.reg
+
+import chisel3.iotesters
+import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
+
+import adept.decoder._
+import adept.alu.AluOps
+import adept.core.AdeptControlSignals
+
+////////////////////////////////////////////////
+// Test Suite for Register Type instructions
+////////////////////////////////////////////////
+class ADD(c: InstructionDecoder) extends DecoderTestBase(c) {
+  private def ADD(rs1: Int, rs2: Int, imm: Int, rd: Int) {
+    val instr = (((127 & imm) << 25) | ((31 & rs2) << 20) | 
+                 ((31 & rs1) << 15) | ((31 & rd) << 7) | op_code.Registers.litValue())     
+    val new_imm = if ((imm >> 6) == 1)
+                    ((0xFFFFFFF << 7) | imm)
+                  else 
+                    imm
+    val trap = if ((imm == 0) || (imm == funct7alu))
+                 0
+               else
+                 1                    
+    poke(c.io.stall_reg, false)
+    poke(c.io.basic.instruction, instr)
+    
+    step(1)
+    
+    expect(c.io.basic.out.registers.we, true)
+    expect(c.io.basic.out.registers.rsd_sel, rd)
+    expect(c.io.basic.out.registers.rs1_sel, rs1)
+    expect(c.io.basic.out.registers.rs2_sel, rs2)
+    expect(c.io.basic.out.immediate, new_imm)
+    if (imm == 0) {
+      expect(c.io.basic.out.trap, trap)
+      expect(c.io.basic.out.alu.op, AluOps.add)    
+    } else if (imm == funct7alu) {
+      expect(c.io.basic.out.trap, trap)
+    } else {
+      expect(c.io.basic.out.trap, trap)
+    }
+    expect(c.io.basic.out.sel_rf_wb, AdeptControlSignals.result_alu)
+    expect(c.io.basic.out.sel_operand_a, AdeptControlSignals.sel_oper_A_rs1)
+    expect(c.io.basic.out.sel_operand_b, AdeptControlSignals.sel_oper_B_rs2)
+  }
+
+  for (i <- 0 until 10000) {
+    var rs1 = rnd.nextInt(32)
+    var rs2 = rnd.nextInt(32)
+    val random = rnd.nextInt(128)
+    val imm = if (random % 2 == 0)
+                0
+              else if (random % 5 == 0)
+                funct7alu
+              else
+                random
+    val rd  = rnd.nextInt(32)
+    
+    ADD(rs1, rs2, imm, rd)
+  }
+}


### PR DESCRIPTION
Change the file `register.scala` in order to check if the 7 MSBs respect the instruction set (`0000000` or `0100000`). When it doesn't happen a trap is generated.

Close ul-lar/Adept#6