### PR TITLE
Fixes Instruction SLLI executes even without the 7 MSBs being 0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ test-basic:
 
 test-module:
 	sbt 'testOnly $(PACKAGE).$(MODULE)Tester'
+
 repl:
 	sbt 'test:runMain $(PACKAGE).$(MODULE)Repl'
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ test-verilator:
 test-basic:
 	sbt 'test:runMain $(PACKAGE).$(MODULE)Main --program-file=$(PROG)'
 
+test-module:
+	sbt 'testOnly $(PACKAGE).$(MODULE)Tester'
 repl:
 	sbt 'test:runMain $(PACKAGE).$(MODULE)Repl'
 

--- a/scripts/run_instr_tests.sh
+++ b/scripts/run_instr_tests.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# Turn echo on
-set -x
-
 if [ -z ${RISCV+x} ]; then
     echo "The RISCV environment variable is not set. Please set it and rerun script."
     exit 1
@@ -11,7 +8,7 @@ fi
 # Create log folder
 mkdir -p logs
 
-TEST_FILE_FOLDER=Adept-TestFiles/instructions
+TEST_FILE_FOLDER=../Adept-TestFiles/instructions
 HEXS=$TEST_FILE_FOLDER/hex
 RESULTS_FOLDER=$TEST_FILE_FOLDER/results/
 TOP=$(pwd)
@@ -26,6 +23,6 @@ for test in $(ls $HEXS); do
     # Run test in verilator
     make test-verilator PROG=$HEXS/$test > $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y)
     # Cut the log and take just the output that we want
-    cat $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y) | grep 0x | sed 's/\[.*\] \[.*\] //g' > $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y)
-    diff $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y) $RESULTS_FOLDER/${test%.hex}/verilator || exit 1
+    cat $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y) | tac | grep "PC = " -m 1 -B32 | sed 's/\[.*\] \[.*\] //g' | tac > $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y)
+    diff -w $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y) $RESULTS_FOLDER/${test%.hex}/verilator exit 1
 done

--- a/scripts/run_instr_tests.sh
+++ b/scripts/run_instr_tests.sh
@@ -8,7 +8,7 @@ fi
 # Create log folder
 mkdir -p logs
 
-TEST_FILE_FOLDER=../Adept-TestFiles/instructions
+TEST_FILE_FOLDER=Adept-TestFiles/instructions
 HEXS=$TEST_FILE_FOLDER/hex
 RESULTS_FOLDER=$TEST_FILE_FOLDER/results/
 TOP=$(pwd)
@@ -24,5 +24,5 @@ for test in $(ls $HEXS); do
     make test-verilator PROG=$HEXS/$test > $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y)
     # Cut the log and take just the output that we want
     cat $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y) | tac | grep "PC = " -m 1 -B32 | sed 's/\[.*\] \[.*\] //g' | tac > $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y)
-    diff -w $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y) $RESULTS_FOLDER/${test%.hex}/verilator exit 1
+    diff -w $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y) $RESULTS_FOLDER/${test%.hex}/verilator
 done

--- a/src/main/scala/Core.scala
+++ b/src/main/scala/Core.scala
@@ -180,6 +180,8 @@ class Adept(config: AdeptConfig) extends Module {
   // Debug Stuff
   ///////////////////////////////////////////////////////////////////
 
+  val not_load_we = RegNext(~io.load.we)
+  
   io.trap := idecode.io.basic.out.trap
 
   // Simulation ends when program detects a write of 0xdead0000 to R13
@@ -187,9 +189,9 @@ class Adept(config: AdeptConfig) extends Module {
     val success = mem.io.instr_out === "h_dead_0737".U
 
     register_file.io.success.getOrElse(false.B) := (success | idecode.io.basic.out.trap) &
-                                                    RegNext(~io.load.we) & ~io.load.we
+                                                    not_load_we & ~io.load.we
     pc.io.success.getOrElse(false.B)            := (success | idecode.io.basic.out.trap) &
-                                                    RegNext(~io.load.we) & ~io.load.we
+                                                    not_load_we & ~io.load.we
     io.success                                  := RegNext(success)
   } else {
     io.success := false.B

--- a/src/main/scala/decoder/I/immediate.scala
+++ b/src/main/scala/decoder/I/immediate.scala
@@ -35,7 +35,7 @@ private class ImmediateControlSignals(override val config: AdeptConfig,
     io.sel_operand_a     := core_ctl_signals.sel_oper_A_rs1
     io.sel_operand_b     := core_ctl_signals.sel_oper_B_imm
 
-    // Check if the 7 MSB are conform with spec when the operation is a shit
+    // Check if the 7 MSB are conform with spec when the operation is a shift
     // immediate 
     when ((msb_imm =/= 0.U && alu_op === alu_ops.sll) ||
 	 ((msb_imm =/= "b0100000".U && msb_imm =/= 0.U)

--- a/src/main/scala/decoder/I/immediate.scala
+++ b/src/main/scala/decoder/I/immediate.scala
@@ -17,7 +17,7 @@ private class ImmediateControlSignals(override val config: AdeptConfig,
     val rs1_sel = instruction(19, 15)
     val rs2_sel = instruction(24, 20)
     val imm     = instruction(31, 20)
-    val msb_imm = instruction(31, 25)
+    val msb_imm = imm(11, 5)
 
     io.registers.we      := true.B
     io.registers.rsd_sel := rsd_sel
@@ -35,9 +35,12 @@ private class ImmediateControlSignals(override val config: AdeptConfig,
     io.sel_operand_a     := core_ctl_signals.sel_oper_A_rs1
     io.sel_operand_b     := core_ctl_signals.sel_oper_B_imm
 
-    // Check if the 7 MSB are conform with spec when the operation is a shit immediate 
-    when ((msb_imm =/= 0.U && alu_op === alu_ops.sll) || ((msb_imm =/= "b0100000".U && msb_imm =/= 0.U) && alu_op === alu_ops.srl)){
-      io.trap := true.B         
+    // Check if the 7 MSB are conform with spec when the operation is a shit
+    // immediate 
+    when ((msb_imm =/= 0.U && alu_op === alu_ops.sll) ||
+	 ((msb_imm =/= "b0100000".U && msb_imm =/= 0.U)
+	 && alu_op === alu_ops.srl)){
+      io.trap := true.B
     } .otherwise {
       io.trap := false.B
     }

--- a/src/main/scala/decoder/I/immediate.scala
+++ b/src/main/scala/decoder/I/immediate.scala
@@ -5,7 +5,6 @@ import chisel3._
 import adept.config.AdeptConfig
 import adept.decoder.{InstructionControlSignals, InstructionDecoderOutput}
 
-// TODO: Throw a trap when the immediate doesn't conform to the spec
 private class ImmediateControlSignals(override val config: AdeptConfig,
                               instruction: UInt, decoder_out: InstructionDecoderOutput)
     extends InstructionControlSignals(config, instruction, decoder_out) {
@@ -18,6 +17,7 @@ private class ImmediateControlSignals(override val config: AdeptConfig,
     val rs1_sel = instruction(19, 15)
     val rs2_sel = instruction(24, 20)
     val imm     = instruction(31, 20)
+    val msb_imm = instruction(31, 25)
 
     io.registers.we      := true.B
     io.registers.rsd_sel := rsd_sel
@@ -27,12 +27,20 @@ private class ImmediateControlSignals(override val config: AdeptConfig,
     io.registers.rs2_sel := rs2_sel
 
     io.immediate         := imm.asSInt
-
-    io.alu.op            := alu_ops.getALUOp(op, imm(11, 5), op_codes.Immediate)
+        
+    val alu_op            = alu_ops.getALUOp(op, imm(11, 5), op_codes.Immediate)
+    io.alu.op            := alu_op
 
     io.sel_rf_wb         := core_ctl_signals.result_alu
     io.sel_operand_a     := core_ctl_signals.sel_oper_A_rs1
     io.sel_operand_b     := core_ctl_signals.sel_oper_B_imm
+
+    // Check if the 7 MSB are conform with spec when the operation is a shit immediate 
+    when ((msb_imm =/= 0.U && alu_op === alu_ops.sll) || ((msb_imm =/= "b0100000".U && msb_imm =/= 0.U) && alu_op === alu_ops.srl)){
+      io.trap := true.B         
+    } .otherwise {
+      io.trap := false.B
+    }
   }
 
 }

--- a/src/main/scala/decoder/I/immediate.scala
+++ b/src/main/scala/decoder/I/immediate.scala
@@ -35,8 +35,8 @@ private class ImmediateControlSignals(override val config: AdeptConfig,
     io.sel_operand_a     := core_ctl_signals.sel_oper_A_rs1
     io.sel_operand_b     := core_ctl_signals.sel_oper_B_imm
 
-    // Check if the 7 MSB are conform with spec when the operation is a shift
-    // immediate 
+    // Check if the 7 MSBs conform to the spec when the operation is a shift
+    // immediate
     when ((msb_imm =/= 0.U && alu_op === alu_ops.sll) ||
 	 ((msb_imm =/= "b0100000".U && msb_imm =/= 0.U)
 	 && alu_op === alu_ops.srl)){

--- a/src/main/scala/decoder/decoder.scala
+++ b/src/main/scala/decoder/decoder.scala
@@ -68,7 +68,6 @@ final class InvalidInstruction(decoder_out: InstructionDecoderOutput) {
   val io = Wire(decoder_out)
 
   io.setDefaults
-  io.trap := true.B
 }
 
 class InstructionDecoder(config: AdeptConfig) extends Module {

--- a/src/main/scala/decoder/decoder.scala
+++ b/src/main/scala/decoder/decoder.scala
@@ -68,6 +68,7 @@ final class InvalidInstruction(decoder_out: InstructionDecoderOutput) {
   val io = Wire(decoder_out)
 
   io.setDefaults
+  io.trap := true.B
 }
 
 class InstructionDecoder(config: AdeptConfig) extends Module {

--- a/src/test/scala/core/AdeptTester.scala
+++ b/src/test/scala/core/AdeptTester.scala
@@ -53,6 +53,7 @@ class AdeptUnitTester(c: Adept, programFileName: String) extends PeekPokeTester(
   }
 
   if (peek(c.io.trap) == 1) {
+    printf ("Trap\n")
     step (1)
   }
 }

--- a/src/test/scala/core/AdeptTester.scala
+++ b/src/test/scala/core/AdeptTester.scala
@@ -41,11 +41,18 @@ class AdeptUnitTester(c: Adept, programFileName: String) extends PeekPokeTester(
   // Lower reset and write_enable. Core should start processing
   poke(c.io.load.we, false)
 
+  step(1)
+
   reset(4)
 
+  step(1)
+
   // Wait for success
-  while(peek(c.io.success) == 0) {
-    expect(c.io.trap, false)
+  while(peek(c.io.success) == 0 && peek(c.io.trap) == 0) {
     step(1)
+  }
+
+  if (peek(c.io.trap) == 1) {
+    step (1)
   }
 }

--- a/src/test/scala/decoder/decoderMain.scala
+++ b/src/test/scala/decoder/decoderMain.scala
@@ -1,0 +1,23 @@
+// Decoder Unit Tester
+package adept.decoder
+
+import chisel3._
+
+import adept.config.AdeptConfig
+import adept.test.common.Common
+
+object DecoderMain extends App {
+  private val config = new AdeptConfig
+
+  val parseArgs = Common(args)
+
+  iotesters.Driver.execute(parseArgs.firrtlArgs, () => new InstructionDecoder(config)) {
+    c => new DecoderUnitTesterAll(c)
+  }
+}
+
+object DecoderRepl extends App {
+  private val config = new AdeptConfig
+
+  iotesters.Driver.executeFirrtlRepl(args, () => new InstructionDecoder(config))
+}

--- a/src/test/scala/decoder/decoderUnitTester.scala
+++ b/src/test/scala/decoder/decoderUnitTester.scala
@@ -7,6 +7,10 @@ import adept.config.AdeptConfig
 
 import adept.decoder.tests.imm._
 
+class DecoderTestBase(c: InstructionDecoder) extends PeekPokeTester(c) {
+  val op_code = new OpCodes
+  val slli = 1  //b001
+}
 
 class DecoderUnitTesterAll(e: InstructionDecoder) extends PeekPokeTester(e) {
     // Immediate Type Instructions

--- a/src/test/scala/decoder/decoderUnitTester.scala
+++ b/src/test/scala/decoder/decoderUnitTester.scala
@@ -1,0 +1,28 @@
+package adept.decoder
+
+import chisel3.iotesters
+import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
+
+import adept.config.AdeptConfig
+
+import adept.decoder.tests.imm._
+
+
+class DecoderUnitTesterAll(e: InstructionDecoder) extends PeekPokeTester(e) {
+    // Immediate Type Instructions
+    new SLLI(e)
+}
+
+class DecoderTester extends ChiselFlatSpec {
+  // Generate configuration
+  val config = new AdeptConfig
+  
+  ///////////////////////////////////////////////////////////////////////////
+  // Immediate Type Instructions
+  ////////////////////////////////////////////////////////////////////////////
+  "Decoder" should s"test SLLI instruction (with verilator)" in {
+    Driver(() => new InstructionDecoder(config), "verilator") {
+      e => new SLLI(e)
+    } should be (true)
+  }
+}

--- a/src/test/scala/decoder/imm_tests.scala
+++ b/src/test/scala/decoder/imm_tests.scala
@@ -1,0 +1,48 @@
+package adept.decoder.tests.imm
+
+import chisel3.iotesters
+import chisel3.iotesters.{ChiselFlatSpec, Driver, PeekPokeTester}
+
+import adept.decoder._
+import adept.alu.AluOps
+import adept.core.AdeptControlSignals
+
+////////////////////////////////////////////////
+// Test Suite for Immediate Type instructions
+////////////////////////////////////////////////
+class SLLI(c: InstructionDecoder) extends PeekPokeTester(c) {
+  private def SLLI(rs1: Int, imm: Int, rd: Int) {
+    val instr = ((imm << 20) | ((31 & rs1) << 15) | (1<<12) | ((31 & rd) << 7) | 19)   
+    val shamt = 31 & imm
+    val new_imm =
+      if ((imm >> 11) == 1)
+        ((0xFFFFF << 12) | imm)
+      else 
+        imm
+    poke(c.io.stall_reg, false)                 
+    poke(c.io.basic.instruction, BigInt(instr)) 
+    step(1)
+    expect(c.io.basic.out.registers.we, true)
+    expect(c.io.basic.out.registers.rsd_sel, rd)
+    expect(c.io.basic.out.registers.rs1_sel, rs1)
+    expect(c.io.basic.out.registers.rs2_sel, shamt)
+    expect(c.io.basic.out.immediate, new_imm)
+    if ((imm >> 5) != 0)
+      expect (c.io.basic.out.trap, 1)
+    else
+      expect (c.io.basic.out.trap, 0)
+    expect(c.io.basic.out.alu.op, AluOps.sll)
+    expect(c.io.basic.out.sel_rf_wb, AdeptControlSignals.result_alu)
+    expect(c.io.basic.out.sel_operand_a, AdeptControlSignals.sel_oper_A_rs1)
+    expect(c.io.basic.out.sel_operand_b, AdeptControlSignals.sel_oper_B_imm)
+  }
+
+  for (i <- 0 until 100) {
+    var rs1 = rnd.nextInt(32)
+    var imm = rnd.nextInt(4096)
+    val rd  = rnd.nextInt(32)
+    
+    SLLI(rs1, imm, rd)
+  }
+}
+

--- a/src/test/scala/decoder/imm_tests.scala
+++ b/src/test/scala/decoder/imm_tests.scala
@@ -10,27 +10,29 @@ import adept.core.AdeptControlSignals
 ////////////////////////////////////////////////
 // Test Suite for Immediate Type instructions
 ////////////////////////////////////////////////
-class SLLI(c: InstructionDecoder) extends PeekPokeTester(c) {
+class SLLI(c: InstructionDecoder) extends DecoderTestBase(c) {
   private def SLLI(rs1: Int, imm: Int, rd: Int) {
-    val instr = ((imm << 20) | ((31 & rs1) << 15) | (1<<12) | ((31 & rd) << 7) | 19)   
+    val instr = ((imm << 20) | ((31 & rs1) << 15) | (slli << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())   
     val shamt = 31 & imm
-    val new_imm =
-      if ((imm >> 11) == 1)
-        ((0xFFFFF << 12) | imm)
-      else 
-        imm
+    val new_imm = if ((imm >> 11) == 1)
+                    ((0xFFFFF << 12) | imm)
+                  else 
+                    imm
+    val trap = if ((imm >> 5) != 0)
+                 1
+               else
+                 0
     poke(c.io.stall_reg, false)                 
-    poke(c.io.basic.instruction, BigInt(instr)) 
+    poke(c.io.basic.instruction, instr)
+
     step(1)
+
     expect(c.io.basic.out.registers.we, true)
     expect(c.io.basic.out.registers.rsd_sel, rd)
     expect(c.io.basic.out.registers.rs1_sel, rs1)
     expect(c.io.basic.out.registers.rs2_sel, shamt)
     expect(c.io.basic.out.immediate, new_imm)
-    if ((imm >> 5) != 0)
-      expect (c.io.basic.out.trap, 1)
-    else
-      expect (c.io.basic.out.trap, 0)
+    expect (c.io.basic.out.trap, trap)
     expect(c.io.basic.out.alu.op, AluOps.sll)
     expect(c.io.basic.out.sel_rf_wb, AdeptControlSignals.result_alu)
     expect(c.io.basic.out.sel_operand_a, AdeptControlSignals.sel_oper_A_rs1)

--- a/src/test/scala/decoder/imm_tests.scala
+++ b/src/test/scala/decoder/imm_tests.scala
@@ -32,7 +32,7 @@ class SLLI(c: InstructionDecoder) extends DecoderTestBase(c) {
     expect(c.io.basic.out.registers.rs1_sel, rs1)
     expect(c.io.basic.out.registers.rs2_sel, shamt)
     expect(c.io.basic.out.immediate, new_imm)
-    expect (c.io.basic.out.trap, trap)
+    expect(c.io.basic.out.trap, trap)
     expect(c.io.basic.out.alu.op, AluOps.sll)
     expect(c.io.basic.out.sel_rf_wb, AdeptControlSignals.result_alu)
     expect(c.io.basic.out.sel_operand_a, AdeptControlSignals.sel_oper_A_rs1)


### PR DESCRIPTION
Change the file immediate.scala to check if the 7 MSBs follow the instruction
spec when the operation is a shift immediate. To test the correct execution,
the file AdeptTester.scala is also edited in order to print the correct values
of PC and registers when a trap is generated. In this file the first `step(1)`
is to set to low the signal load_we and the second `step(1)`, that is
introduced in this commit, is to assert reset. It's important to mention that,
when there is an assembly instruction that will generate a trap, said
instruction should be preceded by two NOPs so that the instructions in the
pipeline may be written to the register file.

Fixes #2 