### PR TITLE
Create ADDI Chisel flat spec tests for decoder

### DIFF
--- a/scripts/run_instr_tests.sh
+++ b/scripts/run_instr_tests.sh
@@ -25,8 +25,9 @@ for test in $(ls $HEXS); do
     # Cut the log and take just the output that we want
     if grep -q 'Trap' $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y); then
 	tac $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y) | grep "Trap" -m 1 -B33 | sed 's/\[.*\] \[.*\] //g' | tac > $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y)
-	else
-		tac $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y) | grep "PC = " -m 1 -B32 | sed 's/\[.*\] \[.*\] //g' | tac > $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y)
+    else
+	tac $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y) | grep "PC = " -m 1 -B32 | sed 's/\[.*\] \[.*\] //g' | tac > $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y)
     fi
-	diff -w $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y) $RESULTS_FOLDER/${test%.hex}/verilator
+    diff -w $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y) $RESULTS_FOLDER/${test%.hex}/verilator
+
 done

--- a/scripts/run_instr_tests.sh
+++ b/scripts/run_instr_tests.sh
@@ -23,6 +23,10 @@ for test in $(ls $HEXS); do
     # Run test in verilator
     make test-verilator PROG=$HEXS/$test > $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y)
     # Cut the log and take just the output that we want
-    cat $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y) | tac | grep "PC = " -m 1 -B32 | sed 's/\[.*\] \[.*\] //g' | tac > $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y)
-    diff -w $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y) $RESULTS_FOLDER/${test%.hex}/verilator
+    if grep -q 'Trap' $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y); then
+	tac $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y) | grep "Trap" -m 1 -B33 | sed 's/\[.*\] \[.*\] //g' | tac > $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y)
+	else
+		tac $LOG_FOLDER/verilator_$test_$(date +%d-%m-%Y) | grep "PC = " -m 1 -B32 | sed 's/\[.*\] \[.*\] //g' | tac > $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y)
+    fi
+	diff -w $LOG_FOLDER/verilator_result_$test_$(date +%d-%m-%Y) $RESULTS_FOLDER/${test%.hex}/verilator
 done

--- a/src/test/scala/decoder/decoderUnitTester.scala
+++ b/src/test/scala/decoder/decoderUnitTester.scala
@@ -9,7 +9,15 @@ import adept.decoder.tests.imm._
 
 class DecoderTestBase(c: InstructionDecoder) extends PeekPokeTester(c) {
   val op_code = new OpCodes
-  val slli = 1  //b001 
+  val slli = Integer.parseInt("001", 2)
+
+  def signExtension (imm: Int, nbits: Int) : Int = {
+    if ((imm >> (nbits-1)) == 1) {
+      ((0xFFFFFFFF << nbits) | imm)
+    } else {
+      imm
+    }
+  }
 }
 
 class DecoderUnitTesterAll(e: InstructionDecoder) extends PeekPokeTester(e) {

--- a/src/test/scala/decoder/decoderUnitTester.scala
+++ b/src/test/scala/decoder/decoderUnitTester.scala
@@ -9,11 +9,12 @@ import adept.decoder.tests.imm._
 
 class DecoderTestBase(c: InstructionDecoder) extends PeekPokeTester(c) {
   val op_code = new OpCodes
-  val slli = 1  //b001
+  val slli = 1  //b001 
 }
 
 class DecoderUnitTesterAll(e: InstructionDecoder) extends PeekPokeTester(e) {
     // Immediate Type Instructions
+    new ADDI(e)
     new SLLI(e)
 }
 
@@ -24,6 +25,11 @@ class DecoderTester extends ChiselFlatSpec {
   ///////////////////////////////////////////////////////////////////////////
   // Immediate Type Instructions
   ////////////////////////////////////////////////////////////////////////////
+  "Decoder" should s"test ADDI instruction (with verilator)" in {
+    Driver(() => new InstructionDecoder(config), "verilator") {
+      e => new ADDI(e)
+    } should be (true)
+  }
   "Decoder" should s"test SLLI instruction (with verilator)" in {
     Driver(() => new InstructionDecoder(config), "verilator") {
       e => new SLLI(e)

--- a/src/test/scala/decoder/imm_tests.scala
+++ b/src/test/scala/decoder/imm_tests.scala
@@ -10,6 +10,39 @@ import adept.core.AdeptControlSignals
 ////////////////////////////////////////////////
 // Test Suite for Immediate Type instructions
 ////////////////////////////////////////////////
+class ADDI(c: InstructionDecoder) extends DecoderTestBase(c) {
+  private def ADDI(rs1: Int, imm: Int, rd: Int) {
+    val instr = (((4095 & imm) << 20) | ((31 & rs1) << 15) | ((31 & rd) << 7) | op_code.Immediate.litValue())
+    val new_imm = if ((imm >> 11) == 1)
+                    ((0xFFFFF << 12) | imm)
+                  else
+                    imm
+    poke(c.io.stall_reg, false)
+    poke(c.io.basic.instruction, instr)
+
+    step(1)
+
+    expect(c.io.basic.out.registers.we, true)
+    expect(c.io.basic.out.registers.rsd_sel, rd)
+    expect(c.io.basic.out.registers.rs1_sel, rs1)
+    expect(c.io.basic.out.immediate, new_imm)
+    expect(c.io.basic.out.trap, 0)
+    expect(c.io.basic.out.alu.op, AluOps.add)
+    expect(c.io.basic.out.sel_rf_wb, AdeptControlSignals.result_alu)
+    expect(c.io.basic.out.sel_operand_a, AdeptControlSignals.sel_oper_A_rs1)
+    expect(c.io.basic.out.sel_operand_b, AdeptControlSignals.sel_oper_B_imm)
+  }
+
+  for (i <- 0 until 100) {
+    var rs1 = rnd.nextInt(32)
+    var imm = rnd.nextInt(4096)
+    val rd  = rnd.nextInt(32)
+
+    ADDI(rs1, imm, rd)
+  }
+}
+
+
 class SLLI(c: InstructionDecoder) extends DecoderTestBase(c) {
   private def SLLI(rs1: Int, imm: Int, rd: Int) {
     val instr = ((imm << 20) | ((31 & rs1) << 15) | (slli << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())   

--- a/src/test/scala/decoder/imm_tests.scala
+++ b/src/test/scala/decoder/imm_tests.scala
@@ -12,11 +12,8 @@ import adept.core.AdeptControlSignals
 ////////////////////////////////////////////////
 class ADDI(c: InstructionDecoder) extends DecoderTestBase(c) {
   private def ADDI(rs1: Int, imm: Int, rd: Int) {
-    val instr = (((4095 & imm) << 20) | ((31 & rs1) << 15) | ((31 & rd) << 7) | op_code.Immediate.litValue())
-    val new_imm = if ((imm >> 11) == 1)
-                    ((0xFFFFF << 12) | imm)
-                  else
-                    imm
+    val instr = ((imm << 20) | ((31 & rs1) << 15) | ((31 & rd) << 7) | op_code.Immediate.litValue())
+    val new_imm = signExtension (imm, 12)
     poke(c.io.stall_reg, false)
     poke(c.io.basic.instruction, instr)
 
@@ -47,14 +44,12 @@ class SLLI(c: InstructionDecoder) extends DecoderTestBase(c) {
   private def SLLI(rs1: Int, imm: Int, rd: Int) {
     val instr = ((imm << 20) | ((31 & rs1) << 15) | (slli << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())   
     val shamt = 31 & imm
-    val new_imm = if ((imm >> 11) == 1)
-                    ((0xFFFFF << 12) | imm)
-                  else 
-                    imm
-    val trap = if ((imm >> 5) != 0)
+    val new_imm = signExtension (imm, 12)
+    val trap = if ((imm >> 5) != 0) {
                  1
-               else
+               } else {
                  0
+               }
     poke(c.io.stall_reg, false)                 
     poke(c.io.basic.instruction, instr)
 

--- a/src/test/scala/decoder/imm_tests.scala
+++ b/src/test/scala/decoder/imm_tests.scala
@@ -13,7 +13,7 @@ import adept.core.AdeptControlSignals
 class ADDI(c: InstructionDecoder) extends DecoderTestBase(c) {
   private def ADDI(rs1: Int, imm: Int, rd: Int) {
     val instr = ((imm << 20) | ((31 & rs1) << 15) | ((31 & rd) << 7) | op_code.Immediate.litValue())
-    val new_imm = signExtension (imm, 12)
+    val new_imm = signExtension(imm, 12)
     poke(c.io.stall_reg, false)
     poke(c.io.basic.instruction, instr)
 


### PR DESCRIPTION
This PR adds the specific test for the instruction ADDI to the chisel flat spec
tests for the decoder. It also changes the `run_instr_tests.sh` script in
order to parse the log resultant of a test that generate a trap correctly.