### PR TITLE
Create ORI Chisel flat spec tests for decoder

### DIFF
--- a/src/test/scala/decoder/decoderUnitTester.scala
+++ b/src/test/scala/decoder/decoderUnitTester.scala
@@ -12,6 +12,7 @@ class DecoderTestBase(c: InstructionDecoder) extends PeekPokeTester(c) {
   val op_code = new OpCodes
   val slli = Integer.parseInt("001", 2)
   val slti = Integer.parseInt("010", 2)
+  val sltiu = Integer.parseInt("011", 2)
   val funct7alu = Integer.parseInt("0100000", 2);
 
   def signExtension(imm: Int, nbits: Int) : Int = {
@@ -28,6 +29,7 @@ class DecoderUnitTesterAll(e: InstructionDecoder) extends PeekPokeTester(e) {
     new ADDI(e)
     new SLTI(e)
     new SLLI(e)
+    new SLTIU(e)
 
     // Register Type Instructions
     new ADD(e)
@@ -49,6 +51,11 @@ class DecoderTester extends ChiselFlatSpec {
   "Decoder" should s"test SLTI instruction (with verilator)" in {
     Driver(() => new InstructionDecoder(config), "verilator") {
       e => new SLTI(e)
+    } should be (true)
+  }
+  "Decoder" should s"test SLTIU instruction (with verilator)" in {
+    Driver(() => new InstructionDecoder(config), "verilator") {
+      e => new SLLI(e)
     } should be (true)
   }
   "Decoder" should s"test SLLI instruction (with verilator)" in {

--- a/src/test/scala/decoder/decoderUnitTester.scala
+++ b/src/test/scala/decoder/decoderUnitTester.scala
@@ -10,9 +10,10 @@ import adept.decoder.tests.reg._
 
 class DecoderTestBase(c: InstructionDecoder) extends PeekPokeTester(c) {
   val op_code = new OpCodes
-  val slli = Integer.parseInt("001", 2)
-  val slti = Integer.parseInt("010", 2)
-  val sltiu = Integer.parseInt("011", 2)
+  val sll = Integer.parseInt("001", 2)
+  val slt = Integer.parseInt("010", 2)
+  val sltu = Integer.parseInt("011", 2)
+  val xor = Integer.parseInt("100", 2)
   val funct7alu = Integer.parseInt("0100000", 2);
 
   def signExtension(imm: Int, nbits: Int) : Int = {
@@ -30,6 +31,7 @@ class DecoderUnitTesterAll(e: InstructionDecoder) extends PeekPokeTester(e) {
     new SLTI(e)
     new SLLI(e)
     new SLTIU(e)
+    new XORI(e)
 
     // Register Type Instructions
     new ADD(e)
@@ -55,7 +57,12 @@ class DecoderTester extends ChiselFlatSpec {
   }
   "Decoder" should s"test SLTIU instruction (with verilator)" in {
     Driver(() => new InstructionDecoder(config), "verilator") {
-      e => new SLLI(e)
+      e => new SLTIU(e)
+    } should be (true)
+  }
+  "Decoder" should s"test XORI instruction (with verilator)" in {
+    Driver(() => new InstructionDecoder(config), "verilator") {
+      e => new XORI(e)
     } should be (true)
   }
   "Decoder" should s"test SLLI instruction (with verilator)" in {

--- a/src/test/scala/decoder/decoderUnitTester.scala
+++ b/src/test/scala/decoder/decoderUnitTester.scala
@@ -14,6 +14,7 @@ class DecoderTestBase(c: InstructionDecoder) extends PeekPokeTester(c) {
   val slt = Integer.parseInt("010", 2)
   val sltu = Integer.parseInt("011", 2)
   val xor = Integer.parseInt("100", 2)
+  val or = Integer.parseInt("110", 2)
   val funct7alu = Integer.parseInt("0100000", 2);
 
   def signExtension(imm: Int, nbits: Int) : Int = {
@@ -32,6 +33,7 @@ class DecoderUnitTesterAll(e: InstructionDecoder) extends PeekPokeTester(e) {
     new SLLI(e)
     new SLTIU(e)
     new XORI(e)
+    new ORI(e)
 
     // Register Type Instructions
     new ADD(e)
@@ -63,6 +65,11 @@ class DecoderTester extends ChiselFlatSpec {
   "Decoder" should s"test XORI instruction (with verilator)" in {
     Driver(() => new InstructionDecoder(config), "verilator") {
       e => new XORI(e)
+    } should be (true)
+  }
+  "Decoder" should s"test ORI instruction (with verilator)" in {
+    Driver(() => new InstructionDecoder(config), "verilator") {
+      e => new ORI(e)
     } should be (true)
   }
   "Decoder" should s"test SLLI instruction (with verilator)" in {

--- a/src/test/scala/decoder/imm_tests.scala
+++ b/src/test/scala/decoder/imm_tests.scala
@@ -130,6 +130,36 @@ class XORI(c: InstructionDecoder) extends DecoderTestBase(c) {
   }
 }
 
+class ORI(c: InstructionDecoder) extends DecoderTestBase(c) {
+  private def ORI(rs1: Int, imm: Int, rd: Int) {
+    val instr = ((imm << 20) | ((31 & rs1) << 15) | (or << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())
+    val new_imm = signExtension(imm, 12)
+
+    poke(c.io.stall_reg, false)
+    poke(c.io.basic.instruction, instr)
+
+    step(1)
+
+    expect(c.io.basic.out.registers.we, true)
+    expect(c.io.basic.out.registers.rsd_sel, rd)
+    expect(c.io.basic.out.registers.rs1_sel, rs1)
+    expect(c.io.basic.out.immediate, new_imm)
+    expect(c.io.basic.out.trap, 0)
+    expect(c.io.basic.out.alu.op, AluOps.or)
+    expect(c.io.basic.out.sel_rf_wb, AdeptControlSignals.result_alu)
+    expect(c.io.basic.out.sel_operand_a, AdeptControlSignals.sel_oper_A_rs1)
+    expect(c.io.basic.out.sel_operand_b, AdeptControlSignals.sel_oper_B_imm)
+  }
+
+  for (i <- 0 until 100) {
+    val rs1 = rnd.nextInt(32)
+    val imm = -2048 + rnd.nextInt(4096)
+    val rd  = rnd.nextInt(32)
+
+    ORI(rs1, imm, rd)
+  }
+}
+
 class SLLI(c: InstructionDecoder) extends DecoderTestBase(c) {
   private def SLLI(rs1: Int, imm: Int, rd: Int) {
     val instr = ((imm << 20) | ((31 & rs1) << 15) | (sll << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())

--- a/src/test/scala/decoder/imm_tests.scala
+++ b/src/test/scala/decoder/imm_tests.scala
@@ -33,7 +33,7 @@ class ADDI(c: InstructionDecoder) extends DecoderTestBase(c) {
 
   for (i <- 0 until 100) {
     val rs1 = rnd.nextInt(32)
-    val imm = rnd.nextInt(4096)
+    val imm = -2048 + rnd.nextInt(4096)
     val rd  = rnd.nextInt(32)
 
     ADDI(rs1, imm, rd)
@@ -44,6 +44,7 @@ class SLTI(c: InstructionDecoder) extends DecoderTestBase(c) {
   private def SLTI(rs1: Int, imm: Int, rd: Int) {
     val instr = ((imm << 20) | ((31 & rs1) << 15) | (slti << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())
     val new_imm = signExtension(imm, 12)
+    
     poke(c.io.stall_reg, false)
     poke(c.io.basic.instruction, instr)
 
@@ -62,10 +63,40 @@ class SLTI(c: InstructionDecoder) extends DecoderTestBase(c) {
 
   for (i <- 0 until 100) {
     val rs1 = rnd.nextInt(32)
-    val imm = rnd.nextInt(4096)
+    val imm = -2048 + rnd.nextInt(4096)
     val rd  = rnd.nextInt(32)
 
     SLTI(rs1, imm, rd)
+  }
+}
+
+class SLTIU(c: InstructionDecoder) extends DecoderTestBase(c) {
+  private def SLTIU(rs1: Int, imm: Int, rd: Int) {
+    val instr = ((imm << 20) | ((31 & rs1) << 15) | (sltiu << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())
+    val new_imm = signExtension(imm, 12)
+    
+    poke(c.io.stall_reg, false)
+    poke(c.io.basic.instruction, instr)
+
+    step(1)
+
+    expect(c.io.basic.out.registers.we, true)
+    expect(c.io.basic.out.registers.rsd_sel, rd)
+    expect(c.io.basic.out.registers.rs1_sel, rs1)
+    expect(c.io.basic.out.immediate, new_imm)
+    expect(c.io.basic.out.trap, 0)
+    expect(c.io.basic.out.alu.op, AluOps.slt)
+    expect(c.io.basic.out.sel_rf_wb, AdeptControlSignals.result_alu)
+    expect(c.io.basic.out.sel_operand_a, AdeptControlSignals.sel_oper_A_rs1)
+    expect(c.io.basic.out.sel_operand_b, AdeptControlSignals.sel_oper_B_imm)
+  }
+
+  for (i <- 0 until 100) {
+    val rs1 = rnd.nextInt(32)
+    val imm = -2048 + rnd.nextInt(4096)
+    val rd  = rnd.nextInt(32)
+
+    SLTIU(rs1, imm, rd)
   }
 }
 
@@ -99,10 +130,9 @@ class SLLI(c: InstructionDecoder) extends DecoderTestBase(c) {
 
   for (i <- 0 until 100) {
     val rs1 = rnd.nextInt(32)
-    val imm = rnd.nextInt(4096)
+    val imm = -2048 + rnd.nextInt(4096)
     val rd  = rnd.nextInt(32)
 
     SLLI(rs1, imm, rd)
   }
 }
-

--- a/src/test/scala/decoder/imm_tests.scala
+++ b/src/test/scala/decoder/imm_tests.scala
@@ -42,7 +42,7 @@ class ADDI(c: InstructionDecoder) extends DecoderTestBase(c) {
 
 class SLTI(c: InstructionDecoder) extends DecoderTestBase(c) {
   private def SLTI(rs1: Int, imm: Int, rd: Int) {
-    val instr = ((imm << 20) | ((31 & rs1) << 15) | (slti << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())
+    val instr = ((imm << 20) | ((31 & rs1) << 15) | (slt << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())
     val new_imm = signExtension(imm, 12)
     
     poke(c.io.stall_reg, false)
@@ -72,7 +72,7 @@ class SLTI(c: InstructionDecoder) extends DecoderTestBase(c) {
 
 class SLTIU(c: InstructionDecoder) extends DecoderTestBase(c) {
   private def SLTIU(rs1: Int, imm: Int, rd: Int) {
-    val instr = ((imm << 20) | ((31 & rs1) << 15) | (sltiu << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())
+    val instr = ((imm << 20) | ((31 & rs1) << 15) | (sltu << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())
     val new_imm = signExtension(imm, 12)
     
     poke(c.io.stall_reg, false)
@@ -85,7 +85,7 @@ class SLTIU(c: InstructionDecoder) extends DecoderTestBase(c) {
     expect(c.io.basic.out.registers.rs1_sel, rs1)
     expect(c.io.basic.out.immediate, new_imm)
     expect(c.io.basic.out.trap, 0)
-    expect(c.io.basic.out.alu.op, AluOps.slt)
+    expect(c.io.basic.out.alu.op, AluOps.sltu)
     expect(c.io.basic.out.sel_rf_wb, AdeptControlSignals.result_alu)
     expect(c.io.basic.out.sel_operand_a, AdeptControlSignals.sel_oper_A_rs1)
     expect(c.io.basic.out.sel_operand_b, AdeptControlSignals.sel_oper_B_imm)
@@ -100,9 +100,39 @@ class SLTIU(c: InstructionDecoder) extends DecoderTestBase(c) {
   }
 }
 
+class XORI(c: InstructionDecoder) extends DecoderTestBase(c) {
+  private def XORI(rs1: Int, imm: Int, rd: Int) {
+    val instr = ((imm << 20) | ((31 & rs1) << 15) | (xor << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())
+    val new_imm = signExtension(imm, 12)
+
+    poke(c.io.stall_reg, false)
+    poke(c.io.basic.instruction, instr)
+
+    step(1)
+
+    expect(c.io.basic.out.registers.we, true)
+    expect(c.io.basic.out.registers.rsd_sel, rd)
+    expect(c.io.basic.out.registers.rs1_sel, rs1)
+    expect(c.io.basic.out.immediate, new_imm)
+    expect(c.io.basic.out.trap, 0)
+    expect(c.io.basic.out.alu.op, AluOps.xor)
+    expect(c.io.basic.out.sel_rf_wb, AdeptControlSignals.result_alu)
+    expect(c.io.basic.out.sel_operand_a, AdeptControlSignals.sel_oper_A_rs1)
+    expect(c.io.basic.out.sel_operand_b, AdeptControlSignals.sel_oper_B_imm)
+  }
+
+  for (i <- 0 until 100) {
+    val rs1 = rnd.nextInt(32)
+    val imm = -2048 + rnd.nextInt(4096)
+    val rd  = rnd.nextInt(32)
+
+    XORI(rs1, imm, rd)
+  }
+}
+
 class SLLI(c: InstructionDecoder) extends DecoderTestBase(c) {
   private def SLLI(rs1: Int, imm: Int, rd: Int) {
-    val instr = ((imm << 20) | ((31 & rs1) << 15) | (slli << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())
+    val instr = ((imm << 20) | ((31 & rs1) << 15) | (sll << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())
     val shamt = 31 & imm
     val new_imm = signExtension (imm, 12)
     val trap = if ((imm >> 5) != 0) {


### PR DESCRIPTION
This PR adds the specific test for the instruction ORI to the chisel flat
spec tests for the decoder