### PR TITLE
 Create SLL Chisel flat spec tests for decoder and fix the decoder

### DIFF
--- a/src/main/scala/decoder/I/register.scala
+++ b/src/main/scala/decoder/I/register.scala
@@ -33,10 +33,9 @@ private class RegisterControlSignals(override val config: AdeptConfig,
     io.sel_rf_wb         := core_ctl_signals.result_alu
 
     // Check if the 7 MSBs respect the instruction set
-    when ((imm =/= 0.U && imm =/= "b0100000".U) ||
-          (imm === 0.U && (alu_op === alu_ops.sub || alu_op === alu_ops.sra)) ||
-          (imm === "b0100000".U &&
-          (alu_op =/= alu_ops.sub && alu_op =/= alu_ops.sra))) {
+    when (((alu_op === alu_ops.sub || alu_op === alu_ops.sra) &&
+          imm =/= "b0100000".U) || (imm =/= 0.U && alu_op =/= alu_ops.sub &&
+          alu_op =/= alu_ops.sra)) {
       io.trap := true.B
     } .otherwise {
       io.trap := false.B

--- a/src/main/scala/decoder/I/register.scala
+++ b/src/main/scala/decoder/I/register.scala
@@ -23,7 +23,8 @@ private class RegisterControlSignals(override val config: AdeptConfig,
     io.registers.rsd_sel := rsd_sel
     io.registers.we      := true.B
 
-    io.alu.op            := alu_ops.getALUOp(op, imm, op_codes.Registers)
+    val alu_op            = alu_ops.getALUOp(op, imm, op_codes.Registers)
+    io.alu.op            := alu_op
 
     io.immediate         := imm.asSInt
 
@@ -32,7 +33,10 @@ private class RegisterControlSignals(override val config: AdeptConfig,
     io.sel_rf_wb         := core_ctl_signals.result_alu
 
     // Check if the 7 MSBs respect the instruction set
-    when (imm =/= 0.U && imm =/= "b0100000".U){
+    when ((imm =/= 0.U && imm =/= "b0100000".U) ||
+          (imm === 0.U && (alu_op === alu_ops.sub || alu_op === alu_ops.sra)) ||
+          (imm === "b0100000".U &&
+          (alu_op =/= alu_ops.sub && alu_op =/= alu_ops.sra))) {
       io.trap := true.B
     } .otherwise {
       io.trap := false.B

--- a/src/test/scala/decoder/decoderUnitTester.scala
+++ b/src/test/scala/decoder/decoderUnitTester.scala
@@ -42,7 +42,7 @@ class DecoderTester extends ChiselFlatSpec {
   ///////////////////////////////////////////////////////////////////////////
   // Immediate Type Instructions
   ////////////////////////////////////////////////////////////////////////////
-  /*"Decoder" should s"test ADDI instruction (with verilator)" in {
+  "Decoder" should s"test ADDI instruction (with verilator)" in {
     Driver(() => new InstructionDecoder(config), "verilator") {
       e => new ADDI(e)
     } should be (true)
@@ -56,7 +56,7 @@ class DecoderTester extends ChiselFlatSpec {
     Driver(() => new InstructionDecoder(config), "verilator") {
       e => new SLLI(e)
     } should be (true)
-  }*/
+  }
 
   ////////////////////////////////////////////////////////////////////////////
   // Register Type Instructions

--- a/src/test/scala/decoder/decoderUnitTester.scala
+++ b/src/test/scala/decoder/decoderUnitTester.scala
@@ -10,8 +10,8 @@ import adept.decoder.tests.reg._
 
 class DecoderTestBase(c: InstructionDecoder) extends PeekPokeTester(c) {
   val op_code = new OpCodes
-  val slli = Integer.parseInt("001", 2)
-  val slti = Integer.parseInt("010", 2)
+  val sll = Integer.parseInt("001", 2)
+  val slt = Integer.parseInt("010", 2)
   val funct7alu = Integer.parseInt("0100000", 2);
 
   def signExtension(imm: Int, nbits: Int) : Int = {
@@ -32,6 +32,7 @@ class DecoderUnitTesterAll(e: InstructionDecoder) extends PeekPokeTester(e) {
     // Register Type Instructions
     new ADD(e)
     new SUB(e)
+    new SLL(e)
 }
 
 class DecoderTester extends ChiselFlatSpec {
@@ -41,7 +42,7 @@ class DecoderTester extends ChiselFlatSpec {
   ///////////////////////////////////////////////////////////////////////////
   // Immediate Type Instructions
   ////////////////////////////////////////////////////////////////////////////
-  "Decoder" should s"test ADDI instruction (with verilator)" in {
+  /*"Decoder" should s"test ADDI instruction (with verilator)" in {
     Driver(() => new InstructionDecoder(config), "verilator") {
       e => new ADDI(e)
     } should be (true)
@@ -55,7 +56,7 @@ class DecoderTester extends ChiselFlatSpec {
     Driver(() => new InstructionDecoder(config), "verilator") {
       e => new SLLI(e)
     } should be (true)
-  }
+  }*/
 
   ////////////////////////////////////////////////////////////////////////////
   // Register Type Instructions
@@ -68,6 +69,11 @@ class DecoderTester extends ChiselFlatSpec {
   "Decoder" should s"test SUB instruction (with verilator)" in {
     Driver(() => new InstructionDecoder(config), "verilator") {
       e => new SUB(e)
+    } should be (true)
+  }
+  "Decoder" should s"test SLL instruction (with verilator)" in {
+    Driver(() => new InstructionDecoder(config), "verilator") {
+      e => new SLL(e)
     } should be (true)
   }
 }


### PR DESCRIPTION
This PR adds the specific test for the instruction SLL to the chisel flat spec
tests for the decoder.

The file `register.scala` was also modified in order to fix a bug when the decoder generates a trap.

Closes #13 