### PR TITLE
Create ANDI Chisel flat spec tests for decoder

### DIFF
--- a/src/test/scala/decoder/decoderUnitTester.scala
+++ b/src/test/scala/decoder/decoderUnitTester.scala
@@ -15,6 +15,7 @@ class DecoderTestBase(c: InstructionDecoder) extends PeekPokeTester(c) {
   val sltu = Integer.parseInt("011", 2)
   val xor = Integer.parseInt("100", 2)
   val or = Integer.parseInt("110", 2)
+  val and = Integer.parseInt("111", 2)
   val funct7alu = Integer.parseInt("0100000", 2);
 
   def signExtension(imm: Int, nbits: Int) : Int = {
@@ -34,6 +35,7 @@ class DecoderUnitTesterAll(e: InstructionDecoder) extends PeekPokeTester(e) {
     new SLTIU(e)
     new XORI(e)
     new ORI(e)
+    new ANDI(e)
 
     // Register Type Instructions
     new ADD(e)
@@ -71,6 +73,11 @@ class DecoderTester extends ChiselFlatSpec {
   "Decoder" should s"test XORI instruction (with verilator)" in {
     Driver(() => new InstructionDecoder(config), "verilator") {
       e => new XORI(e)
+    } should be (true)
+  }
+  "Decoder" should s"test ANDI instruction (with verilator)" in {
+    Driver(() => new InstructionDecoder(config), "verilator") {
+      e => new ANDI(e)
     } should be (true)
   }
   "Decoder" should s"test SLLI instruction (with verilator)" in {

--- a/src/test/scala/decoder/imm_tests.scala
+++ b/src/test/scala/decoder/imm_tests.scala
@@ -160,6 +160,36 @@ class ORI(c: InstructionDecoder) extends DecoderTestBase(c) {
   }
 }
 
+class ANDI(c: InstructionDecoder) extends DecoderTestBase(c) {
+  private def ANDI(rs1: Int, imm: Int, rd: Int) {
+    val instr = ((imm << 20) | ((31 & rs1) << 15) | (and << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())
+    val new_imm = signExtension(imm, 12)
+
+    poke(c.io.stall_reg, false)
+    poke(c.io.basic.instruction, instr)
+
+    step(1)
+
+    expect(c.io.basic.out.registers.we, true)
+    expect(c.io.basic.out.registers.rsd_sel, rd)
+    expect(c.io.basic.out.registers.rs1_sel, rs1)
+    expect(c.io.basic.out.immediate, new_imm)
+    expect(c.io.basic.out.trap, 0)
+    expect(c.io.basic.out.alu.op, AluOps.and)
+    expect(c.io.basic.out.sel_rf_wb, AdeptControlSignals.result_alu)
+    expect(c.io.basic.out.sel_operand_a, AdeptControlSignals.sel_oper_A_rs1)
+    expect(c.io.basic.out.sel_operand_b, AdeptControlSignals.sel_oper_B_imm)
+  }
+
+  for (i <- 0 until 100) {
+    val rs1 = rnd.nextInt(32)
+    val imm = -2048 + rnd.nextInt(4096)
+    val rd  = rnd.nextInt(32)
+
+    ANDI(rs1, imm, rd)
+  }
+}
+
 class SLLI(c: InstructionDecoder) extends DecoderTestBase(c) {
   private def SLLI(rs1: Int, imm: Int, rd: Int) {
     val instr = ((imm << 20) | ((31 & rs1) << 15) | (sll << 12) | ((31 & rd) << 7) | op_code.Immediate.litValue())


### PR DESCRIPTION
This commit adds the specific test for the instruction ANDI to the chisel
flat spec tests for the decoder.